### PR TITLE
Typo in function name - "preix" to "prefix"

### DIFF
--- a/advanced-topics/wirebox-object-populator/populatefromquerywithprefix.md
+++ b/advanced-topics/wirebox-object-populator/populatefromquerywithprefix.md
@@ -1,4 +1,4 @@
-# populateFromQueryWithPreix
+# populateFromQueryWithPrefix
 
 Populates an Object using only specific columns from a query. Useful for performing a query with joins that needs to populate multiple objects.
 


### PR DESCRIPTION
Sigh. I don't know what consequences this will have in GitBooks, but I think it's kinda important to have the function name spelled right.