### PR TITLE
Update virtual-inheritance.md to fix typo

### DIFF
--- a/advanced-topics/virtual-inheritance.md
+++ b/advanced-topics/virtual-inheritance.md
@@ -11,5 +11,5 @@ map("BaseModel").to("model.base.BaseModel");
 map("UserService").to("model.users.UserService").virtualInheritance("BaseModel");
 ```
 
-This will grab all methods and properties in the `AbstractModel` CFC and mix them into the `UserService`, then create a virtual `$super` scope which will map to an instantiated instance of the `BaseModel` object.
+This will grab all methods and properties in the `BaseModel` CFC and mix them into the `UserService`, then create a virtual `$super` scope which will map to an instantiated instance of the `BaseModel` object.
 


### PR DESCRIPTION
Replaced 'AbstractModel' with 'BaseModel' to match the example